### PR TITLE
Add repository and homepage to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
   "main": "./index.js",
   "author": "Jan Nicklas",
   "license": "MIT",
+  "repository": "jantimon/cpuprofile-webpack-plugin",
+  "homepage": "https://github.com/jantimon/cpuprofile-webpack-plugin#cpuprofile-webpack-plugin"
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"


### PR DESCRIPTION
Now it doesn't have link to repo and homepage

![image](https://user-images.githubusercontent.com/5969049/66779337-8b5c3a00-eed6-11e9-9e59-b34e7790ab17.png)

After this,  it would be easy to jump to sourcecode from npm/yarn page.
For example take a look on webpack page (right column).

![image](https://user-images.githubusercontent.com/5969049/66779324-8303ff00-eed6-11e9-98ae-aac1805e12d2.png)


